### PR TITLE
docs: fix dev server startup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This shows a vite application that functions as a single-spa application.
 
 ```sh
 pnpm install
-pnpm run dev --https
+pnpm run dev -- --https
 open https://localhost:3000/src/main.js # The cert will be insecure - tell your browser to trust it
 open 'https://single-spa-playground.org/playground/instant-test?name=vite-test&framework=vue&useNativeModules=true&url=https%3A%2F%2Flocalhost%3A3000%2Fsrc%2Fmain.js'
 ```


### PR DESCRIPTION
exiting command `pnpm run dev --https`  throws Unknown option: 'https' error because `vite https` is invalid.

`pnpm run dev -- --https` translates to `vite --https` which is a valid command.

P.S. Kindly add `hacktoberfest-accepted` label after reviewing/merging this :) 